### PR TITLE
59 speed up building conda environments in GitHub actions

### DIFF
--- a/.github/workflows/lebedigital.yml
+++ b/.github/workflows/lebedigital.yml
@@ -14,7 +14,7 @@ on:
     - cron: '3 15 * * *'
 
 env:
-  CACHE_NUMBER: 0  # increase to reset cache manually
+  CACHE_NUMBER: 2  # increase to reset cache manually
 
 jobs:
   tests:
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: "linux-64"
+          path: "/usr/share/miniconda3/envs/lebedigital"
           key: conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/cache@v2
         with:
-          path: "linux-64"
+          path: "/usr/share/miniconda3/envs/lebedigital"
           key: conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 

--- a/.github/workflows/lebedigital.yml
+++ b/.github/workflows/lebedigital.yml
@@ -9,6 +9,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Runs the workflow once per day at 3:15am
+  schedule:
+    - cron: '3 15 * * *'
+
+env:
+  CACHE_NUMBER: 1  # increase to reset cache manually
 
 jobs:
   tests:
@@ -17,18 +23,26 @@ jobs:
     steps:
       - name: checkout repo content
         uses: actions/checkout@v2
-      - name: setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: setup-conda-environment
+      - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2
         with:
-          environment-file: environment.yml
-          mamba-version: "*"
-          auto-update-conda: true
-          activate-environment: lebedigital
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            activate-environment: lebedigital
+            use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v2
+        with:
+          path: "linux-64"
+          key: conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n lebedigital -f environment.yml
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: run-pytest
         shell: bash -l {0}

--- a/.github/workflows/lebedigital.yml
+++ b/.github/workflows/lebedigital.yml
@@ -50,35 +50,8 @@ jobs:
           cd $GITHUB_WORKSPACE/tests/
           pytest -s -W error::UserWarning --ignore=ModelCalibration/tests/simulation
 
-  minimum-working-example:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: checkout repo content
-        uses: actions/checkout@v2
-      - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-            miniforge-variant: Mambaforge
-            miniforge-version: latest
-            activate-environment: lebedigital
-            use-mamba: true
-
-      - name: Set cache date
-        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-
-      - uses: actions/cache@v2
-        with:
-          path: "/usr/share/miniconda3/envs/lebedigital"
-          key: conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
-        id: cache
-
-      - name: Update environment
-        run: mamba env update -n lebedigital -f environment.yml
-        if: steps.cache.outputs.cache-hit != 'true'
-
       - name: run-minimum-working-example
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/usecases/MinimumWorkingExample/
-          doit
+          doit      

--- a/.github/workflows/lebedigital.yml
+++ b/.github/workflows/lebedigital.yml
@@ -14,7 +14,7 @@ on:
     - cron: '3 15 * * *'
 
 env:
-  CACHE_NUMBER: 1  # increase to reset cache manually
+  CACHE_NUMBER: 0  # increase to reset cache manually
 
 jobs:
   tests:

--- a/.github/workflows/lebedigital.yml
+++ b/.github/workflows/lebedigital.yml
@@ -56,18 +56,26 @@ jobs:
     steps:
       - name: checkout repo content
         uses: actions/checkout@v2
-      - name: setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: setup-conda-environment
+      - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2
         with:
-          environment-file: environment.yml
-          mamba-version: "*"
-          auto-update-conda: true
-          activate-environment: lebedigital
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            activate-environment: lebedigital
+            use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v2
+        with:
+          path: "linux-64"
+          key: conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n lebedigital -f environment.yml
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: run-minimum-working-example
         shell: bash -l {0}


### PR DESCRIPTION
Speed up the building of conda environments by 
1. using mamba (as already done)
2. caching versions once per day (they are only rebuild if either the environment file or the date changes)
3. joining the different task into subsequent steps (to avoid building the same environment twice)
The total time when using a cached version is now reduced to 2:42 (from approximately 10min), if a cached conda environment can be found. A new version can be forced by increasing the CACHE_NUMBER. The key for recreating an environment is actually a hash from the environmentfile, the CACHE_NUMBER and the DATE.
In addition, a cronjob is added to run the actions every day at 3:15am, such that a prebuild version of the environment should usually be available when pushing a new version.