### PR TITLE
187 fixing breaking tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - docker-compose
   - cython
   - numpy
-  - pandas=2.0.1
+  - pandas
   - pyyaml
   - owlready2
   - rdflib
@@ -32,7 +32,7 @@ dependencies:
   - pint=0.20
   - pint-pandas
   - snakemake
-  - pybis
+  - pybis=1.35.5
   - xlsxwriter
   - termcolor
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - docker-compose
   - cython
   - numpy
-  - pandas
+  - pandas=2.0.1
   - pyyaml
   - owlready2
   - rdflib

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
   - sphinx
   - pytest-cov
   - codecov
-  - pydantic
+  - pydantic<2.0
   - seaborn
   - pip:
     - probeye==2.3.0


### PR DESCRIPTION
Should work now. pydantic has some breaking changes with versions >2.0 and something(?) broke in pybis 1.35.6 which caused the issues. I've locked both of them to the last working versions for now.