### PR TITLE
reset pandas to older version, probably conflict with  pint-pandas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - docker-compose
   - cython
   - numpy
-  - pandas
+  - pandas=2.0.3
   - pyyaml
   - owlready2
   - rdflib=6


### PR DESCRIPTION
Pandas is reset to 2.0.3, there are apparently some conflict with pint-pandas